### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/todoist/AbstractTodoistTask.java
+++ b/src/main/java/io/kestra/plugin/todoist/AbstractTodoistTask.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -29,6 +30,7 @@ public abstract class AbstractTodoistTask extends Task {
         description = "Personal API token sent as Bearer auth to Todoist API v1. Keep it in a Kestra Secret; required for all Todoist tasks."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> apiToken;
 
     protected static final String BASE_URL = "https://api.todoist.com/api/v1";

--- a/src/main/java/io/kestra/plugin/todoist/CompleteTask.java
+++ b/src/main/java/io/kestra/plugin/todoist/CompleteTask.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -50,6 +51,7 @@ public class CompleteTask extends AbstractTodoistTask implements RunnableTask<Vo
         description = "Todoist task ID to close"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> taskId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/todoist/CreateTask.java
+++ b/src/main/java/io/kestra/plugin/todoist/CreateTask.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -70,30 +71,35 @@ public class CreateTask extends AbstractTodoistTask implements RunnableTask<Crea
         description = "Visible task title; required"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> content;
 
     @Schema(
         title = "Task description",
         description = "Optional long description"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> taskDescription;
 
     @Schema(
         title = "Priority",
         description = "Priority 1 (highest) to 4 (lowest); defaults to Todoist standard when omitted"
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> priority;
 
     @Schema(
         title = "Project ID",
         description = "Target project ID; leave null for Inbox"
     )
+    @PluginProperty(group = "connection")
     private Property<String> projectId;
 
     @Schema(
         title = "Due string",
         description = "Natural-language due date parsed by Todoist (e.g., 'tomorrow', 'next Monday', '2025-12-31')"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> dueString;
 
     @Override

--- a/src/main/java/io/kestra/plugin/todoist/DeleteTask.java
+++ b/src/main/java/io/kestra/plugin/todoist/DeleteTask.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -50,6 +51,7 @@ public class DeleteTask extends AbstractTodoistTask implements RunnableTask<Void
         description = "Todoist task ID to delete"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> taskId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/todoist/GetTask.java
+++ b/src/main/java/io/kestra/plugin/todoist/GetTask.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -52,6 +53,7 @@ public class GetTask extends AbstractTodoistTask implements RunnableTask<GetTask
         description = "Todoist task ID to read"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> taskId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/todoist/ListTasks.java
+++ b/src/main/java/io/kestra/plugin/todoist/ListTasks.java
@@ -23,6 +23,7 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -130,18 +131,21 @@ public class ListTasks extends AbstractTodoistTask implements RunnableTask<ListT
         title = "Project ID",
         description = "Filter tasks by project ID; cannot be combined with filter"
     )
+    @PluginProperty(group = "connection")
     private Property<String> projectId;
 
     @Schema(
         title = "Filter",
         description = "Custom Todoist query (e.g., \"today\", \"overdue\", \"priority 1\"); mutually exclusive with projectId"
     )
+    @PluginProperty(group = "processing")
     private Property<String> filter;
 
     @Schema(
         title = "Limit",
         description = "Maximum tasks per page. When null, the task auto-paginates all results; when set, only one page is fetched (Todoist defaults to 50). Supported on /tasks and /tasks/filter."
     )
+    @PluginProperty(group = "processing")
     private Property<Integer> limit;
 
     @Schema(
@@ -149,6 +153,7 @@ public class ListTasks extends AbstractTodoistTask implements RunnableTask<ListT
         description = "Output mode: FETCH_ONE (first task), FETCH (all in memory), STORE (write stream to internal storage `kestra://`); default FETCH"
     )
     @Builder.Default
+    @PluginProperty(group = "processing")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Override

--- a/src/main/java/io/kestra/plugin/todoist/UpdateTask.java
+++ b/src/main/java/io/kestra/plugin/todoist/UpdateTask.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -70,30 +71,35 @@ public class UpdateTask extends AbstractTodoistTask implements RunnableTask<Upda
         description = "Todoist task ID to update"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> taskId;
 
     @Schema(
         title = "Task content",
         description = "New task title"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> content;
 
     @Schema(
         title = "Task description",
         description = "New description"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> taskDescription;
 
     @Schema(
         title = "Priority",
         description = "Priority 1 (highest) to 4 (lowest)"
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> priority;
 
     @Schema(
         title = "Due string",
         description = "Natural-language due date (e.g., 'tomorrow', 'next Monday', '2025-12-31')"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> dueString;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712